### PR TITLE
🙈 Update .gitignore for cmake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,18 @@ Testing/
 test_Debug/
 tally-*
 voting_results*
+
+# cmake
+CMakeLists.txt.user
+CMakeCache.txt
+CMakeFiles
+CMakeScripts
+Testing
+Makefile
+cmake_install.cmake
+install_manifest.txt
+compile_commands.json
+CTestTestfile.cmake
+_deps
+
+ElectionGuardConfig.cmake


### PR DESCRIPTION
cmake files that are generated on build or cmake commands should be ignored. 

The files ignored are:
1. Default files prescribed by 
https://github.com/github/gitignore/blob/master/CMake.gitignore

2. ElectionGuardConfig.cmake