### PR TITLE
💚Fix Windows and MacOS Shared Library Build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,12 +74,17 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "GNU")
     target_compile_options(electionguard PUBLIC -Werror -Wenum-compare)
 endif()
 
+# Link gmp library
+find_package(GMP REQUIRED)
+target_link_libraries(electionguard ${GMP_LIBRARY})
+
 # Set the public include directory depending on if the target is being exported
 # or installed
 target_include_directories(electionguard
     SYSTEM PUBLIC
         $<INSTALL_INTERFACE:include>
         $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
+        $<BUILD_INTERFACE:${GMP_INCLUDE_DIR}>
     PRIVATE
         ${PROJECT_SOURCE_DIR}/src/electionguard
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,6 +78,13 @@ endif()
 find_package(GMP REQUIRED)
 target_link_libraries(electionguard ${GMP_LIBRARY})
 
+if (MINGW)
+    # Link BCrypt
+    target_link_libraries(electionguard BCrypt)
+    # Remove lib prefix
+    set_target_properties(electionguard PROPERTIES PREFIX "")
+endif()
+
 # Set the public include directory depending on if the target is being exported
 # or installed
 target_include_directories(electionguard

--- a/src/electionguard/uint4096.c
+++ b/src/electionguard/uint4096.c
@@ -51,7 +51,7 @@ bool uintnwords_succ_o(size_t n, UINT4096_WORD_T *out, const UINT4096_WORD_T *a)
     bool carry = true;
     // timing
     while(carry && n-- > 0) {
-        carry = __builtin_add_overflow(a[n], 1, a+n);
+        carry = __builtin_add_overflow(a[n], 1, out+n);
     }
     return carry;
 }


### PR DESCRIPTION
**Mac**
- Update submodule to latest commit
- Link gmp to ensure that builds have access to gmp.h
- uint4096.c: `a` reference gives error. Substituted with `out` similar to other code sections.

**Windows**
- Link Bcrypt to ensure that builds have access to encryption methods

**Recommended Windows Build Command**
```
cmake -S . -B build -G "MSYS Makefiles" -DBUILD_SHARED_LIBS=ON
cmake --build build
```