### PR TITLE
💚 Simple Build Test for Windows and Mac

### DIFF
--- a/.github/workflows/pr-workflow.yml
+++ b/.github/workflows/pr-workflow.yml
@@ -1,4 +1,4 @@
-name: PR Build
+name: PR Workflow
 
 on: [pull_request]
 
@@ -20,7 +20,7 @@ jobs:
     - name: Build C Library
       run: |
         cmake --version
-        cmake -S . -B build -DBUILD_SHARED_LIBS=ON
+        cmake -S . -B build
         cmake --build build
     - name: 'Build Simple Election'
       run: | 
@@ -37,33 +37,34 @@ jobs:
     - uses: actions/checkout@master
       with:
         submodules: true
-    - name: Install msys2
+    - name: Install msys
       run: |
-        set MSYS_PATH=%CD%\temp\msys2
-        choco install msys2 --params="/InstallDir:%MSYS_PATH% /NoPath" -y
-        echo "::add-path::%MSYS_PATH%\usr\bin"
-        echo "::add-path::%MSYS_PATH%"
-    - name: Install gcc & gmp
-      run: | 
+        $msyspath="msys64"
+        choco install msys2 --params="/InstallDir:$msyspath /NoPath" -y
+        echo "::add-path::$msyspath\usr\bin"
+        echo "::add-path::$msyspath"
+        echo "::add-path::$msyspath\mingw64\bin"
+        echo "::add-path::$msyspath\mingw64\lib"
+        echo "::add-path::$msyspath\mingw64\include"
+    - name: Install gcc and gmp
+      run: |
         pacman --noconfirm -Syu
         pacman --noconfirm -S mingw-w64-x86_64-gcc mingw-w64-x86_64-gmp make
     - name: Build C Library
       run: |
         cmake --version
-        cmake -S . -B build -G "MSYS Makefiles" -DBUILD_SHARED_LIBS=ON
+        cmake -S . -B build -G "MSYS Makefiles"
         cmake --build build
-    # Skip Windows Simple Build - Fails due to ElectionGuard_DIR
     - name: 'Build Simple Election'
-      if: false
-      run: | 
-        setx ElectionGuard_DIR "%CD%/build/ElectionGuard"
+      run: |
+        $env:CMAKE_PREFIX_PATH="./build/ElectionGuard"
         cmake -S examples/simple -B simple_build -G "MSYS Makefiles"
         cmake --build simple_build --target simple
     - name: 'Test Simple Election'
-      if: false
       run: | 
         cd simple_build
-        ./simple
+        $outcome = Invoke-Expression ".\simple.exe"
+        echo $outcome
   macos_build:
     name: 'MacOS Build'
     runs-on: 'macOS-latest'
@@ -72,20 +73,20 @@ jobs:
       with:
         submodules: true
     - name: Install gmp
-      run: brew install gmp
+      run: |
+        brew install gmp
+        echo "::add-path::/usr/local/lib"
+        echo "::add-path::/usr/local/include"
     - name: Build C Library
       run: |
         cmake --version
-        cmake -S . -B build -DBUILD_SHARED_LIBS=ON
+        cmake -S . -B build
         cmake --build build
-    # Skip MacOS Simple Build - Fails due to -lgmp
     - name: 'Build Simple Election'
-      if: false
       run: | 
         ElectionGuard_DIR="$PWD/build/ElectionGuard" cmake -S examples/simple -B simple_build
         cmake --build simple_build --target simple
     - name: 'Test Simple Election'
-      if: false
       run: | 
         cd simple_build
         ./simple

--- a/examples/simple/CMakeLists.txt
+++ b/examples/simple/CMakeLists.txt
@@ -34,7 +34,12 @@ message(STATUS "GMP library found.")
 message(STATUS "GMP include dir is: ${GMP_INCLUDE_DIR}")
 message(STATUS "GMP library is: ${GMP_LIBRARY}")
 
-target_link_libraries(simple electionguard gmp)
+if(APPLE)
+    target_link_libraries(simple electionguard ${GMP_LIBRARY})
+else()
+    target_link_libraries(simple electionguard gmp)
+endif()
+
 
 if (WIN32)
     target_link_libraries(simple Bcrypt)


### PR DESCRIPTION
Simple election tests is now run successfully on Windows and Mac builds
- Windows had issue with gmp location. This was resolved by adding them to the path
- Mac has a similar issue with gmp due to Mojave but is more convoluted. The direct library path had to be added.

Fixes #19 