### PR TITLE
Update Windows README + gitignore test executable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,4 +32,4 @@ CTestTestfile.cmake
 _deps
 
 ElectionGuardConfig.cmake
-simple.exe
+simple_build/

--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ CTestTestfile.cmake
 _deps
 
 ElectionGuardConfig.cmake
+simple.exe

--- a/README-windows.md
+++ b/README-windows.md
@@ -7,7 +7,7 @@
     4. Reopen the MSYS2 prompt and run:
 
             pacman -Syu
-            pacman -S mingw-w64-x86_64-gcc mingw-w64-x86_64-gmp make
+            pacman -S mingw-w64-x86_64-gcc mingw-w64-x86_64-gmp mingw-w64-x86_64-cmake make
 
         (Yes, you should run `pacman -Syu` a second time.)
 
@@ -19,21 +19,16 @@
     1. Open a command prompt and navigate to the directory with the vendor-sdk repo.
     2. Run the following commands:
 
-            mkdir build
-            cd build
-            cmake -G "MSYS Makefiles" ..
-            make
+            cmake -S . -B build -G "MSYS Makefiles" ..
+            cmake --build build
 
-    3. You should now have a `libelectionguard.a`.
+    3. You should now have a `electionguard.a` or `electionguard.dll` (depending on the how cmake was configured).
 3. (Optional) Build the simple example election driver.
     1. Open a command prompt and navigate to the directory with the vendor-sdk repo.
     2. Run the following commands:
 
-            cd examples\simple
-            mkdir build
-            cd build
             set CMAKE_PREFIX_PATH=C:\path\to\vendor-sdk\build\ElectionGuard
-            cmake -G "MSYS Makefiles" ..
-            make
+            cmake -S examples/simple -B simple_build -G "MSYS Makefiles"
+            cmake --build simple_build --target simple
 
     3. You should now have a `simple.exe` that simulates some random voters and generates election record artifacts.


### PR DESCRIPTION
### Checklist
🚨Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [ ] 🤔 **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] ✅ **DO** check open PR's to avoid duplicates.
- [ ] ✅ **DO** keep pull requests small so they can be easily reviewed.
- [ ] ✅ **DO** build locally before pushing.
- [ ] ✅ **DO** make sure tests pass.
- [ ] ✅ **DO** make sure any new changes are documented.
- [ ] ✅ **DO** make sure not to introduce any compiler warnings.
- [ ] ❌**AVOID** breaking the continuous integration build.
- [ ] ❌**AVOID** making significant changes to the overall architecture.


### Description
Updated documentation to run on Windows. If CMAKE was never previously installed on the Windows machine (either from pacman inside of MSYS or in the Windows side from cmake.org), then using the cmake commands with `-G "MSYS Makefiles"` will fail with  `Error: Could not create named generator MSYS Makefiles`. This adds that package to be installed via pacman during the initial setup of MSYS2. This also updates the cmake command's arguments to specify the source and build directories from the root of the project and run make through cmake for consistency. This PR also gitignores the `simple.exe` that is generated from by the example build.