### PR TITLE
Implement returning tracker strings for ballots that have been casted/spoiled

### DIFF
--- a/include/electionguard/api/record_ballots.h
+++ b/include/electionguard/api/record_ballots.h
@@ -17,10 +17,16 @@ bool API_RecordBallots(uint32_t num_selections,
                        struct register_ballot_message *encrypted_ballots,
                        char *export_path,
                        char *filename_prefix,
-                       char **output_filename);                         
+                       char **output_filename,
+                       char **casted_tracker_strings,
+                       char **spoiled_tracker_strings);                         
 
 /**
  * Free the bytes allocated by RecordBallots */
-void API_RecordBallots_free(char *output_filename);    
+void API_RecordBallots_free(char *output_filename,
+                            uint32_t num_cast_ballots,
+                            uint32_t num_spoil_ballots,
+                            char **casted_tracker_strings,
+                            char **spoiled_tracker_strings);    
 
 #endif /* __API_RECORD_BALLOTS_H__ */

--- a/include/electionguard/voting/coordinator.h
+++ b/include/electionguard/voting/coordinator.h
@@ -4,6 +4,7 @@
 #include <stdio.h>
 
 #include <electionguard/voting/messages.h>
+#include <electionguard/voting/tracker.h>
 
 // @todo jwaksbaum What sort of assurances do we make about the
 // machine being shut off? How does it persist votes?
@@ -60,6 +61,10 @@ Voting_Coordinator_cast_ballot(Voting_Coordinator coordinator,
 enum Voting_Coordinator_status
 Voting_Coordinator_spoil_ballot(Voting_Coordinator coordinator,
                                 struct ballot_identifier ballot_id);
+
+/** Get the tracker string for the given ballot_id */
+char *Voting_Coordinator_get_tracker(Voting_Coordinator coordinator,
+                                     struct ballot_identifier ballot_id);
 
 /***************************** EXPORTING BALLOTS ******************************/
 

--- a/src/electionguard/api/record_ballots.c
+++ b/src/electionguard/api/record_ballots.c
@@ -23,7 +23,9 @@ bool API_RecordBallots(uint32_t num_selections,
                        struct register_ballot_message *encrypted_ballots,
                        char *export_path,
                        char *filename_prefix,
-                       char **output_filename)
+                       char **output_filename,
+                       char **casted_tracker_strings,
+                       char **spoiled_tracker_strings)
 {
     bool ok = true;
     
@@ -67,6 +69,8 @@ bool API_RecordBallots(uint32_t num_selections,
             enum Voting_Coordinator_status status =
                 Voting_Coordinator_cast_ballot(coordinator, ballot_identifier);
 
+            casted_tracker_strings[i] = Voting_Coordinator_get_tracker(coordinator, ballot_identifier);
+
             if (status != VOTING_COORDINATOR_SUCCESS)
                 ok = false;
         }
@@ -95,6 +99,8 @@ bool API_RecordBallots(uint32_t num_selections,
 #endif
             enum Voting_Coordinator_status status =
                 Voting_Coordinator_spoil_ballot(coordinator, ballot_identifier);
+
+            spoiled_tracker_strings[i] = Voting_Coordinator_get_tracker(coordinator, ballot_identifier);
 
             if (status != VOTING_COORDINATOR_SUCCESS)
                 ok = false;
@@ -127,10 +133,22 @@ bool API_RecordBallots(uint32_t num_selections,
     return ok;
 }
 
-void API_RecordBallots_free(char *output_filename)
+void API_RecordBallots_free(char *output_filename,
+                            uint32_t num_cast_ballots,
+                            uint32_t num_spoil_ballots,
+                            char **casted_tracker_strings,
+                            char **spoiled_tracker_strings)
 {
     if (output_filename != NULL)
         free(output_filename);
+    
+    for (uint32_t i = 0; i < num_cast_ballots; i++)
+        if (casted_tracker_strings[i] != NULL)
+            free(casted_tracker_strings[i]);
+
+    for (uint32_t i = 0; i < num_spoil_ballots; i++)
+        if (spoiled_tracker_strings[i] != NULL)
+            free(spoiled_tracker_strings[i]);
 }
 
 bool initialize_coordinator(uint32_t num_selections)


### PR DESCRIPTION
### Checklist
🚨Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [x] 🤔 **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] ✅ **DO** check open PR's to avoid duplicates.
- [x] ✅ **DO** keep pull requests small so they can be easily reviewed.
- [x] ✅ **DO** build locally before pushing.
- [x] ✅ **DO** make sure tests pass.
- [x] ✅ **DO** make sure any new changes are documented.
- [x] ✅ **DO** make sure not to introduce any compiler warnings.
- [x] ❌**AVOID** breaking the continuous integration build.
- [x] ❌**AVOID** making significant changes to the overall architecture.


### Description
This is the C implementation to return the arrays of the tracker strings for ballots that have been casted or spoiled.