### PR TITLE
Fix for encrypting ballot boolean arrays with multiple true selections

### DIFF
--- a/examples/api/main.c
+++ b/examples/api/main.c
@@ -2,6 +2,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <time.h>
 #ifdef _MSC_VER
 #include <io.h>
 #endif
@@ -31,7 +32,7 @@ int main()
     // Seed the RNG that we use to generate arbitrary ballots. This
     // relies on the fact that the current implementation of the
     // cryptography does not rely on the built in RNG.
-    srand(100);
+    srand(time(NULL));
 
     struct api_config config = {
         .num_selections = NUM_SELECTIONS,
@@ -173,8 +174,25 @@ bool random_bit() { return 1 & rand(); }
 
 void fill_random_ballot(uint8_t *selections)
 {
+    uint32_t selected_count = 0;
     for (uint32_t i = 0; i < NUM_SELECTIONS; i++)
-        selections[i] = random_bit() ? 1 : 0;
+    {
+        if (random_bit())
+        {
+            selections[i] = 1;
+            selected_count++;
+        }
+        else
+        {
+            selections[i] = 0;
+        }
+    }
+
+    // ensure we dont have all trues or all falses
+    if (selected_count == NUM_SELECTIONS)
+        selections[0] = 0;
+    else if (selected_count == 0)
+        selections[0] = 1;
 
     printf("vote created ");
     for (uint32_t i = 0; i < NUM_SELECTIONS; i++)

--- a/examples/api/main.c
+++ b/examples/api/main.c
@@ -19,7 +19,7 @@ static void fill_random_ballot(uint8_t *selections);
 uint32_t const NUM_TRUSTEES = 3;
 uint32_t const THRESHOLD = 2;
 uint32_t const NUM_ENCRYPTERS = 3;
-uint32_t const NUM_SELECTIONS = 3;
+uint32_t const NUM_SELECTIONS = 6;
 uint32_t const DECRYPTING_TRUSTEES = 2;
 uint32_t const NUM_RANDOM_BALLOT_SELECTIONS = 6;
 
@@ -173,26 +173,9 @@ bool random_bit() { return 1 & rand(); }
 
 void fill_random_ballot(uint8_t *selections)
 {
-    uint8_t selected = 0;
     for (uint32_t i = 0; i < NUM_SELECTIONS; i++)
-    {
-        if (!selected)
-        {
-            selections[i] = random_bit() ? 1 : 0;
-        }
-        else
-        {
-            selections[i] = 0;
-        }
-        if (selections[i])
-        {
-            selected = 1;
-        }
-    }
-    if (!selected)
-    {
-        selections[NUM_SELECTIONS - 1] = 1;
-    }
+        selections[i] = random_bit() ? 1 : 0;
+
     printf("vote created ");
     for (uint32_t i = 0; i < NUM_SELECTIONS; i++)
     {

--- a/examples/simple/main.c
+++ b/examples/simple/main.c
@@ -41,9 +41,6 @@ raw_hash BASE_HASH_CODE = {0, 0xff, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
 
 int main()
 {
-    // Seed the RNG that we use to generate arbitrary ballots. This
-    // relies on the fact that the current implementation of the
-    // cryptography does not rely on the built in RNG.
     srand(time(NULL));
 
     Crypto_parameters_new();

--- a/examples/simple/main.c
+++ b/examples/simple/main.c
@@ -2,6 +2,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <time.h>
 #ifdef _MSC_VER
 #include <io.h>
 #endif
@@ -43,7 +44,7 @@ int main()
     // Seed the RNG that we use to generate arbitrary ballots. This
     // relies on the fact that the current implementation of the
     // cryptography does not rely on the built in RNG.
-    srand(100);
+    srand(time(NULL));
 
     Crypto_parameters_new();
 

--- a/examples/simple/main_voting.c
+++ b/examples/simple/main_voting.c
@@ -112,26 +112,26 @@ static bool random_bit() { return 1 & rand(); }
 
 static void fill_random_ballot(bool *selections)
 {
-    bool selected = false;
+    uint32_t selected_count = 0;
     for (uint32_t i = 0; i < NUM_SELECTIONS; i++)
     {
-        if (!selected)
+        if (random_bit())
         {
-            selections[i] = random_bit();
+            selections[i] = 1;
+            selected_count++;
         }
         else
         {
-            selections[i] = false;
-        }
-        if (selections[i])
-        {
-            selected = true;
+            selections[i] = 0;
         }
     }
-    if (!selected)
-    {
-        selections[NUM_SELECTIONS - 1] = true;
-    }
+
+    // ensure we dont have all trues or all falses
+    if (selected_count == NUM_SELECTIONS)
+        selections[0] = 0;
+    else if (selected_count == 0)
+        selections[0] = 1;
+
     printf("vote created ");
     for (uint32_t i = 0; i < NUM_SELECTIONS; i++)
     {

--- a/examples/simple/main_voting.c
+++ b/examples/simple/main_voting.c
@@ -151,11 +151,6 @@ bool simulate_random_votes(uint32_t encrypter_ix, uint64_t num_ballots)
         bool selections[MAX_SELECTIONS];
 
         fill_random_ballot(selections);
-        if (!Validate_selections(selections, NUM_SELECTIONS))
-        {
-            printf("oops");
-            continue;
-        }
 
         struct register_ballot_message message = {.bytes = NULL};
         struct ballot_tracker tracker = {.bytes = NULL};

--- a/include/electionguard/api/encrypt_ballot.h
+++ b/include/electionguard/api/encrypt_ballot.h
@@ -9,6 +9,7 @@
  * Encrypts the ballot selections given as an array of booleans, 
  * the serialized joint public key, and the current number of ballots. */
 bool API_EncryptBallot(uint8_t *selections_byte_array,
+                       uint32_t expected_num_selected,
                        struct api_config config,
                        uint64_t *current_num_ballots,
                        uint64_t *identifier,

--- a/include/electionguard/voting/encrypter.h
+++ b/include/electionguard/voting/encrypter.h
@@ -69,6 +69,6 @@ struct Voting_Encrypter_encrypt_ballot_r
     struct ballot_tracker tracker;
     struct ballot_identifier id;
 };
-bool Validate_selections(bool const *selections, uint32_t num_selections);
+bool Validate_selections(bool const *selections, uint32_t num_selections, uint32_t *selected_count);
 
 #endif /* __VOTING_ENCRYPTER_H__ */

--- a/include/electionguard/voting/encrypter.h
+++ b/include/electionguard/voting/encrypter.h
@@ -60,7 +60,8 @@ void Voting_Encrypter_free(Voting_Encrypter encrypter);
  * when done, ie. they own them. */
 struct Voting_Encrypter_encrypt_ballot_r
 Voting_Encrypter_encrypt_ballot(Voting_Encrypter encrypter,
-                                bool const *selections);
+                                bool const *selections,
+                                uint32_t expected_num_selected);
 
 struct Voting_Encrypter_encrypt_ballot_r
 {
@@ -69,6 +70,6 @@ struct Voting_Encrypter_encrypt_ballot_r
     struct ballot_tracker tracker;
     struct ballot_identifier id;
 };
-bool Validate_selections(bool const *selections, uint32_t num_selections, uint32_t *selected_count);
+bool Validate_selections(bool const *selections, uint32_t num_selections, uint32_t expected_num_selected);
 
 #endif /* __VOTING_ENCRYPTER_H__ */

--- a/src/electionguard/api/encrypt_ballot.c
+++ b/src/electionguard/api/encrypt_ballot.c
@@ -13,6 +13,7 @@ static struct api_config api_config;
 static Voting_Encrypter encrypter;
 
 bool API_EncryptBallot(uint8_t *selections_byte_array,
+                       uint32_t expected_num_selected,
                        struct api_config config,
                        uint64_t *current_num_ballots,
                        uint64_t *identifier,
@@ -49,7 +50,7 @@ bool API_EncryptBallot(uint8_t *selections_byte_array,
     };
     if (ok)
     {
-        result = Voting_Encrypter_encrypt_ballot(encrypter, selections);
+        result = Voting_Encrypter_encrypt_ballot(encrypter, selections, expected_num_selected);
 
         if (result.status != VOTING_ENCRYPTER_SUCCESS)
             ok = false;

--- a/src/electionguard/api/encrypt_ballot.c
+++ b/src/electionguard/api/encrypt_ballot.c
@@ -36,9 +36,6 @@ bool API_EncryptBallot(uint8_t *selections_byte_array,
         selections[i] = selections_byte_array[i] == 1;
     }
 
-    if (!Validate_selections(selections, config.num_selections))
-        ok = false;
-
     // Initialize Encrypter
 
     if (ok)

--- a/src/electionguard/crypto.c
+++ b/src/electionguard/crypto.c
@@ -574,7 +574,8 @@ bool Crypto_check_decryption_cp_proof(
 //Check the proof, true means the proof checked
 _Bool Crypto_check_aggregate_cp_proof(struct cp_proof_rep proof,
                                       struct encryption_rep encryption,
-                                      struct hash base_hash, mpz_t public_key)
+                                      struct hash base_hash, mpz_t public_key,
+                                      uint32_t l_int)
 {
 
     _Bool result = true;
@@ -611,8 +612,14 @@ _Bool Crypto_check_aggregate_cp_proof(struct cp_proof_rep proof,
 
     result &= (0 == mpz_cmp(gv, aac));
 
-    //L is 1 for now, so this is g^LC when this multiplication happens it should be mod q
-    pow_mod_p(glc, generator, my_C.digest);
+    // number of selections set to L
+    mpz_t L;
+    mpz_init(L);
+    mpz_set_ui(L, l_int);
+    mul_mod_q(L, L, my_C.digest);
+
+    // g^(LC)
+    pow_mod_p(glc, generator, L);
     // K^v
     pow_mod_p(glckv, public_key, proof.response);
     // g^LC * K^v

--- a/src/electionguard/crypto_reps.h
+++ b/src/electionguard/crypto_reps.h
@@ -181,7 +181,8 @@ void Crypto_dis_proof_free(struct dis_proof_rep *dst);
 
 bool Crypto_check_aggregate_cp_proof(struct cp_proof_rep proof,
                                       struct encryption_rep encryption,
-                                      struct hash base_hash, mpz_t public_key);
+                                      struct hash base_hash, mpz_t public_key,
+                                      uint32_t l_int);
 
 void Crypto_generate_aggregate_cp_proof(struct cp_proof_rep *result,
                                         RandomSource source, mpz_t nonce,

--- a/src/electionguard/voting/encrypter.c
+++ b/src/electionguard/voting/encrypter.c
@@ -164,28 +164,26 @@ Voting_Encrypter_Crypto_status_convert(enum Crypto_status status)
     }
 }
 
-bool Validate_selections(bool const *selections, uint32_t num_selections, uint32_t *selected_count)
+bool Validate_selections(bool const *selections, uint32_t num_selections, uint32_t expected_num_selected)
 {
-    *selected_count = 0;
+    uint32_t count = 0;
     for (uint32_t i = 0; i < num_selections; i++)
     {
         if (selections[i])
-            *selected_count += 1;
+            count += 1;
     }
-    // we at least know we shouldn't have a ballot with nothing selected
-    // and we shouldn't have a ballot with everything selected
-    return (*selected_count > 0 && *selected_count < num_selections) ? true : false;
+    return count == expected_num_selected ? true : false;
 }
 struct Voting_Encrypter_encrypt_ballot_r
 Voting_Encrypter_encrypt_ballot(Voting_Encrypter encrypter,
-                                bool const *selections)
+                                bool const *selections,
+                                uint32_t expected_num_selected)
 {
 
     struct Voting_Encrypter_encrypt_ballot_r balotR;
     balotR.status = VOTING_ENCRYPTER_SUCCESS;
-    uint32_t selected_count;
     // validate selection
-    if (!Validate_selections(selections, encrypter->num_selections, &selected_count))
+    if (!Validate_selections(selections, encrypter->num_selections, expected_num_selected))
         balotR.status = VOTING_ENCRYPTER_SELECTION_ERROR;
     if (balotR.status == VOTING_ENCRYPTER_SUCCESS)
     // Construct the ballot id
@@ -270,7 +268,7 @@ Voting_Encrypter_encrypt_ballot(Voting_Encrypter encrypter,
         if (!Crypto_check_aggregate_cp_proof(encrypted_ballot.cp_proof, tally,
                                              encrypter->base_hash,
                                              encrypter->joint_key.public_key,
-                                             selected_count))
+                                             expected_num_selected))
         {
             balotR.status = VOTING_ENCRYPTER_UNKNOWN_ERROR;
         }


### PR DESCRIPTION
### Checklist
🚨Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [x] 🤔 **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] ✅ **DO** check open PR's to avoid duplicates.
- [x] ✅ **DO** keep pull requests small so they can be easily reviewed.
- [x] ✅ **DO** build locally before pushing.
- [x] ✅ **DO** make sure tests pass.
- [x] ✅ **DO** make sure any new changes are documented.
- [x] ✅ **DO** make sure not to introduce any compiler warnings.
- [x] ❌**AVOID** breaking the continuous integration build.
- [x] ❌**AVOID** making significant changes to the overall architecture.


### Description
Fix for encrypting ballot boolean arrays with multiple true selections. This also repurposes `Validate_selections` method since it's already counting the number of true selections. The api example test was also simplified since we no longer have to make sure we only have 1 true selection.