### PR TITLE
Implement return of tally results as uint array

### DIFF
--- a/examples/api/main.c
+++ b/examples/api/main.c
@@ -143,16 +143,23 @@ int main()
     printf("\n--- Tally & Decrypt Votes ---\n");
 
     char *tally_filename;
+    uint32_t tally_results[config.num_selections];
     if (ok)
     {
         char *output_path = "../"; // This outputs to the directy above the cwd.
         char *output_prefix = "tally-";
         ok = API_TallyVotes(config, trustee_states, DECRYPTING_TRUSTEES,
-                ballots_filename, output_path, output_prefix, &tally_filename);
+                ballots_filename, output_path, output_prefix, &tally_filename, tally_results);
 
         if (ok)
+        {
+            for (uint32_t i = 0; i < config.num_selections; i++)
+            {
+                printf("Tally %u results = %u\n", i, tally_results[i]);
+            }
             printf("Tally from ballots input successful!\nCheck output file \"%s\"\n",
                 tally_filename);
+        }
     }
 
     // Cleanup

--- a/examples/simple/main_decryption.c
+++ b/examples/simple/main_decryption.c
@@ -61,11 +61,18 @@ bool decryption(FILE *in, FILE *out, struct trustee_state *trustee_states)
 
     if (ok)
     {
+        uint32_t tally_results[NUM_SELECTIONS];
         enum Decryption_Coordinator_status status =
-            Decryption_Coordinator_all_fragments_received(coordinator, out);
+            Decryption_Coordinator_all_fragments_received(coordinator, out, tally_results);
 
         if (status != DECRYPTION_COORDINATOR_SUCCESS)
             ok = false;
+
+            
+        for (uint32_t i = 0; i < NUM_SELECTIONS; i++)
+        {
+            printf("Tally %u results = %u\n", i, tally_results[i]);
+        }
     }
 
     for (uint32_t i = 0; i < NUM_TRUSTEES; i++)

--- a/include/electionguard/api/tally_votes.h
+++ b/include/electionguard/api/tally_votes.h
@@ -13,7 +13,8 @@ bool API_TallyVotes(struct api_config config,
                     char *ballots_filename, 
                     char *export_path,
                     char *filename_prefix,
-                    char **output_filename);
+                    char **output_filename,
+                    uint32_t *tally_results_array);
 
 /**
  * Free the bytes allocated by TallyVotes */

--- a/include/electionguard/decryption/coordinator.h
+++ b/include/electionguard/decryption/coordinator.h
@@ -95,6 +95,7 @@ Decryption_Coordinator_receive_fragments(Decryption_Coordinator c,
 */
 enum Decryption_Coordinator_status
 Decryption_Coordinator_all_fragments_received(Decryption_Coordinator c,
-                                              FILE *out);
+                                              FILE *out,
+                                              uint32_t *tally_results_array);
 
 #endif

--- a/src/electionguard/api/tally_votes.c
+++ b/src/electionguard/api/tally_votes.c
@@ -15,7 +15,8 @@ static bool tally_ballots(char *in_ballots_filename);
 static bool decrypt_tally_shares(uint32_t num_decrypting_trustees);
 static bool decrypt_tally_decryption_fragments(
     bool *requests_present, struct decryption_fragments_request *requests);
-static bool export_tally_votes(char *export_path, char *filename_prefix, char **output_filename);
+static bool export_tally_votes(char *export_path, char *filename_prefix,
+                               char **output_filename, uint32_t *tally_results_array);
 
 // Global state
 static struct api_config api_config;
@@ -28,7 +29,8 @@ bool API_TallyVotes(struct api_config config,
                     char *ballots_filename, 
                     char *export_path,
                     char *filename_prefix,
-                    char **output_filename)
+                    char **output_filename,
+                    uint32_t *tally_results_array)
 {
     bool ok = true;
 
@@ -77,7 +79,7 @@ bool API_TallyVotes(struct api_config config,
         ok = decrypt_tally_decryption_fragments(request_present, requests);
 
     if (ok)
-        ok = export_tally_votes(export_path, filename_prefix, output_filename);
+        ok = export_tally_votes(export_path, filename_prefix, output_filename, tally_results_array);
 
     // Cleanup
 
@@ -254,7 +256,8 @@ bool decrypt_tally_decryption_fragments(
     return ok;
 }
 
-bool export_tally_votes(char *export_path, char *filename_prefix, char **output_filename)
+bool export_tally_votes(char *export_path, char *filename_prefix,
+                        char **output_filename, uint32_t *tally_results_array)
 {
     bool ok = true;
     char *default_prefix = "electionguard_tally-";
@@ -269,7 +272,7 @@ bool export_tally_votes(char *export_path, char *filename_prefix, char **output_
         FILE *out = fopen(*output_filename, "w+");
 
         enum Decryption_Coordinator_status status =
-            Decryption_Coordinator_all_fragments_received(coordinator, out);
+            Decryption_Coordinator_all_fragments_received(coordinator, out, tally_results_array);
 
         if (status != DECRYPTION_COORDINATOR_SUCCESS)
             ok = false;

--- a/src/electionguard/decryption/coordinator.c
+++ b/src/electionguard/decryption/coordinator.c
@@ -370,7 +370,8 @@ static bool Decryption_Coordinator_all_trustees_seen_or_compensated(
 
 enum Decryption_Coordinator_status
 Decryption_Coordinator_all_fragments_received(Decryption_Coordinator c,
-                                              FILE *out)
+                                              FILE *out,
+                                              uint32_t *tally_results_array)
 {
     enum Decryption_Coordinator_status status = DECRYPTION_COORDINATOR_SUCCESS;
 
@@ -402,7 +403,10 @@ Decryption_Coordinator_all_fragments_received(Decryption_Coordinator c,
 
         if (status == DECRYPTION_COORDINATOR_SUCCESS)
         {
-            printf("Tally %lu \n", mpz_get_ui(decrypted_tally));
+            tally_results_array[i] = mpz_get_ui(decrypted_tally);
+#ifdef DEBUG_PRINT
+            printf("Tally %lu: %u \n", i, tally_results_array[i]);
+#endif
 
             const char *preamble_format = "tally %" PRIu64 ": ";
             const int expected_len = snprintf(NULL, 0, preamble_format, i);


### PR DESCRIPTION
### Checklist
🚨Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [x] 🤔 **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] ✅ **DO** check open PR's to avoid duplicates.
- [x] ✅ **DO** keep pull requests small so they can be easily reviewed.
- [x] ✅ **DO** build locally before pushing.
- [x] ✅ **DO** make sure tests pass.
- [x] ✅ **DO** make sure any new changes are documented.
- [x] ✅ **DO** make sure not to introduce any compiler warnings.
- [x] ❌**AVOID** breaking the continuous integration build.
- [x] ❌**AVOID** making significant changes to the overall architecture.


### Description
Implement return of tally results as uint array. Tally file is still the encrypted results, but the array of ints can be returned to the api caller so it can display the unencrypted result numbers.