### PR TITLE
55655  - Unsafe usage of string related APIs

### DIFF
--- a/src/electionguard/api/filename.c
+++ b/src/electionguard/api/filename.c
@@ -1,5 +1,10 @@
 #include "api/filename.h"
 
+#ifdef _WIN32
+#define __USE_SECURE_APIS__
+#elif __STDC_LIB_EXT1__
+#define __USE_SECURE_APIS__
+#endif
 
 bool generate_unique_filename(char *path_in, char *prefix_in, char* default_prefix, char *filename_out)
 {
@@ -8,10 +13,10 @@ bool generate_unique_filename(char *path_in, char *prefix_in, char* default_pref
     char prefix[FILENAME_MAX];
     char path[FILENAME_MAX];
     char *inUsePrefix = default_prefix;
+    size_t path_len = 0;
 
     // if path is provided, check the last char in the string to make sure it has the appropriate slash
-#ifdef _WIN32
-#elif __STDC_LIB_EXT1__
+#ifdef __USE_SECURE_APIS__
     errno_t err = strcpy_s(path, FILENAME_MAX, path_in);
     if (0 != err)
     {
@@ -19,8 +24,8 @@ bool generate_unique_filename(char *path_in, char *prefix_in, char* default_pref
         goto Exit;
     }
 #else
-    size_t tmp_len = strlen(path_in);
-    if (tmp_len >= FILENAME_MAX)
+    path_len = strlen(path_in);
+    if (path_len >= FILENAME_MAX)
 	{
         ok = false;
         goto Exit;
@@ -29,10 +34,8 @@ bool generate_unique_filename(char *path_in, char *prefix_in, char* default_pref
     strcpy(path, path_in);
 #endif
 
-size_t path_len = 0;
 
-#ifdef _WIN32
-#elif __STDC_LIB_EXT1__
+#ifdef __USE_SECURE_APIS__
     path_len = strlen_s(path, FILENAME_MAX);
     if (path_len == 0 || path_len == FILENAME_MAX)
     {
@@ -55,8 +58,7 @@ size_t path_len = 0;
         char path_end_char = path_in[path_len-1];
         if (path_end_char != directory_separator[0])
         {
-#ifdef _WIN32
-#elif __STDC_LIB_EXT1__
+#ifdef __USE_SECURE_APIS__
             err = strcat_s(path, FILENAME_MAX, directory_separator);
             if (0 != err)
             {
@@ -83,8 +85,7 @@ size_t path_len = 0;
     else
         prefix_size = strlen(inUsePrefix);
 
-#ifdef _WIN32
-#elif __STDC_LIB_EXT1__
+#ifdef __USE_SECURE_APIS__
     err = strcpy_s(prefix, FILENAME_MAX, inUsePrefix);
 
 	if (0 != err)

--- a/src/electionguard/api/filename.c
+++ b/src/electionguard/api/filename.c
@@ -36,7 +36,7 @@ bool generate_unique_filename(char *path_in, char *prefix_in, char* default_pref
 
 
 #ifdef __USE_SECURE_APIS__
-    path_len = strlen_s(path, FILENAME_MAX);
+    path_len = strnlen_s(path, FILENAME_MAX);
     if (path_len == 0 || path_len == FILENAME_MAX)
     {
         ok = false;

--- a/src/electionguard/api/filename.c
+++ b/src/electionguard/api/filename.c
@@ -7,10 +7,43 @@ bool generate_unique_filename(char *path_in, char *prefix_in, char* default_pref
 
     char prefix[FILENAME_MAX];
     char path[FILENAME_MAX];
-    
+    char *inUsePrefix = default_prefix;
+
     // if path is provided, check the last char in the string to make sure it has the appropriate slash
+#ifdef _WIN32
+#elif __STDC_LIB_EXT1__
+    errno_t err = strcpy_s(path, FILENAME_MAX, path_in);
+    if (0 != err)
+    {
+        ok = false;
+        goto Exit;
+    }
+#else
+    size_t tmp_len = strlen(path_in);
+    if (tmp_len >= FILENAME_MAX)
+	{
+        ok = false;
+        goto Exit;
+    }
+
     strcpy(path, path_in);
-    size_t path_len = strlen(path);
+#endif
+
+size_t path_len = 0;
+
+#ifdef _WIN32
+#elif __STDC_LIB_EXT1__
+    path_len = strlen_s(path, FILENAME_MAX);
+    if (path_len == 0 || path_len == FILENAME_MAX)
+    {
+        ok = false;
+        goto Exit;
+    }
+#else
+    path_len = strlen(path);
+#endif
+
+
     if (path_len > 0)
     {
         char *directory_separator;
@@ -22,16 +55,52 @@ bool generate_unique_filename(char *path_in, char *prefix_in, char* default_pref
         char path_end_char = path_in[path_len-1];
         if (path_end_char != directory_separator[0])
         {
+#ifdef _WIN32
+#elif __STDC_LIB_EXT1__
+            err = strcat_s(path, FILENAME_MAX, directory_separator);
+            if (0 != err)
+            {
+                ok = false;
+                goto Exit;
+            }
+#else
+            path_len += 1; 
+            if (path_len >= FILENAME_MAX)
+            {
+                ok = false;
+                goto Exit;
+            }
+
             strcat(path, directory_separator);
+#endif
         }
     }
 
-    // if prefix is provided for filename, use it, otherwise use the default
+	// if prefix is provided for filename, use it, otherwise use the default
     size_t prefix_size = strlen(prefix_in);
     if (prefix_size > 0)
-        strcpy(prefix, prefix_in);
+        inUsePrefix = prefix_in;
     else
-        strcpy(prefix, default_prefix);
+        prefix_size = strlen(inUsePrefix);
+
+#ifdef _WIN32
+#elif __STDC_LIB_EXT1__
+    err = strcpy_s(prefix, FILENAME_MAX, inUsePrefix);
+
+	if (0 != err)
+    {
+        ok = false;
+        goto Exit;
+    }
+#else
+    if (prefix_size >= FILENAME_MAX)
+    {
+        ok = false;
+        goto Exit;
+    }
+
+    strcpy(prefix, inUsePrefix);
+#endif
 
     // get current epoch time
     time_t now = time(NULL);
@@ -39,8 +108,9 @@ bool generate_unique_filename(char *path_in, char *prefix_in, char* default_pref
     int32_t status = snprintf(filename_out, FILENAME_MAX, "%s%s%ld", path, prefix, now);
 
 
-    if (status < 0)
+    if (status < 0 || status == FILENAME_MAX)
         ok = false;
 
+Exit:
     return ok;
 }


### PR DESCRIPTION
55655  - Usage of unsafe string related APIs could lead to potential buffer overflow
For Windows & C11 compilers, we switched to the usage of *_s version of the APIs as recommended.
For other compilers, additional checks to prevent buffer overflow have been added.

### Checklist
🚨Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [ ] 🤔 **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] ✅ **DO** check open PR's to avoid duplicates.
- [x] ✅ **DO** keep pull requests small so they can be easily reviewed.
- [x] ✅ **DO** build locally before pushing.
- [x] ✅ **DO** make sure tests pass.
- [ ] ✅ **DO** make sure any new changes are documented.
- [x] ✅ **DO** make sure not to introduce any compiler warnings.
- [x] ❌**AVOID** breaking the continuous integration build.
- [x] ❌**AVOID** making significant changes to the overall architecture.


### Description
Please describe your pull request.

💔Thank you!