### PR TITLE
Use BCrypt for get byte on windows

### DIFF
--- a/src/electionguard/random_source.c
+++ b/src/electionguard/random_source.c
@@ -58,18 +58,23 @@ void RandomSource_free(RandomSource source)
 #endif
 }
 
-uint8_t RandomSource_get_byte(RandomSource source)
+enum RandomSource_status RandomSource_get_byte(RandomSource source, uint8_t ret)
 {
+    enum RandomSource_status result = RANDOM_SOURCE_SUCCESS;
     size_t item_count;
-    uint8_t ret;
 #ifdef HAVE_BCRYPTGENRANDOM
-    //NTSTATUS ntstatus =
-        //BCryptGenRandom(NULL, &ret, 1, BCRYPT_USE_SYSTEM_PREFERRED_RNG);
-        ret = 1;
+    NTSTATUS ntstatus =
+        BCryptGenRandom(NULL, &ret, 1, BCRYPT_USE_SYSTEM_PREFERRED_RNG);
+
+        if (ntstatus != STATUS_SUCCESS)
+        {
+            result = RANDOM_SOURCE_IO_ERROR;
+        }
+        
 #else
     fread(&ret, 1, 1, source->dev_random);
 #endif
-    return ret;
+    return result;
 }
 
 enum RandomSource_status RandomSource_uniform_o(RandomSource source,

--- a/src/electionguard/random_source.c
+++ b/src/electionguard/random_source.c
@@ -5,6 +5,7 @@
 
 #ifdef HAVE_BCRYPTGENRANDOM
 #include <windows.h>
+#include <assert.h>
 #include <ntstatus.h>
 #include <bcrypt.h>
 #endif
@@ -63,9 +64,9 @@ uint8_t RandomSource_get_byte(RandomSource source)
     size_t item_count;
     uint8_t ret;
 #ifdef HAVE_BCRYPTGENRANDOM
-    //NTSTATUS ntstatus =
-        //BCryptGenRandom(NULL, &ret, 1, BCRYPT_USE_SYSTEM_PREFERRED_RNG);
-        ret = 1;
+    NTSTATUS ntstatus =
+        BCryptGenRandom(NULL, &ret, 1, BCRYPT_USE_SYSTEM_PREFERRED_RNG);
+    assert(ntstatus == STATUS_SUCCESS);
 #else
     fread(&ret, 1, 1, source->dev_random);
 #endif

--- a/src/electionguard/random_source.c
+++ b/src/electionguard/random_source.c
@@ -58,23 +58,18 @@ void RandomSource_free(RandomSource source)
 #endif
 }
 
-enum RandomSource_status RandomSource_get_byte(RandomSource source, uint8_t ret)
+uint8_t RandomSource_get_byte(RandomSource source)
 {
-    enum RandomSource_status result = RANDOM_SOURCE_SUCCESS;
     size_t item_count;
+    uint8_t ret;
 #ifdef HAVE_BCRYPTGENRANDOM
-    NTSTATUS ntstatus =
-        BCryptGenRandom(NULL, &ret, 1, BCRYPT_USE_SYSTEM_PREFERRED_RNG);
-
-        if (ntstatus != STATUS_SUCCESS)
-        {
-            result = RANDOM_SOURCE_IO_ERROR;
-        }
-        
+    //NTSTATUS ntstatus =
+        //BCryptGenRandom(NULL, &ret, 1, BCRYPT_USE_SYSTEM_PREFERRED_RNG);
+        ret = 1;
 #else
     fread(&ret, 1, 1, source->dev_random);
 #endif
-    return result;
+    return ret;
 }
 
 enum RandomSource_status RandomSource_uniform_o(RandomSource source,

--- a/src/electionguard/random_source.h.in
+++ b/src/electionguard/random_source.h.in
@@ -26,7 +26,7 @@ struct RandomSource_uniform_r {
     enum RandomSource_status status;
     uint4096 result;
 };
-uint8_t RandomSource_get_byte(RandomSource);
+enum RandomSource_status RandomSource_get_byte(RandomSource source, uint8_t ret);
 
 // Uses rejection sampling to pick a number between 1 and modulus_default-1,
 // inclusive.

--- a/src/electionguard/random_source.h.in
+++ b/src/electionguard/random_source.h.in
@@ -26,7 +26,7 @@ struct RandomSource_uniform_r {
     enum RandomSource_status status;
     uint4096 result;
 };
-enum RandomSource_status RandomSource_get_byte(RandomSource source, uint8_t ret);
+uint8_t RandomSource_get_byte(RandomSource);
 
 // Uses rejection sampling to pick a number between 1 and modulus_default-1,
 // inclusive.

--- a/src/electionguard/rsa.c
+++ b/src/electionguard/rsa.c
@@ -37,7 +37,8 @@ void generate_keys(rsa_private_key* priv_key, rsa_public_key* pub_key)
     /* Select p */
     for(int i = 0; i < BUFFER_SIZE; i++)
     {
-        buffer[i] = RandomSource_get_byte(source) % 0xFF;
+        enum RandomSource_status source_status = RandomSource_get_byte(source, buffer[i]) % 0xFF;
+        assert(source_status == RANDOM_SOURCE_SUCCESS);
     }
 
     buffer[0] |= 0xC0;                                  // Set the top two bits to 1 to ensure int(tmp) is relatively large

--- a/src/electionguard/rsa.c
+++ b/src/electionguard/rsa.c
@@ -37,7 +37,7 @@ void generate_keys(rsa_private_key* priv_key, rsa_public_key* pub_key)
     /* Select p */
     for(int i = 0; i < BUFFER_SIZE; i++)
     {
-        buffer[i] = RandomSource_get_byte(source) % 0xFF;
+        buffer[i] = RandomSource_get_byte(source);
     }
 
     buffer[0] |= 0xC0;                                  // Set the top two bits to 1 to ensure int(tmp) is relatively large

--- a/src/electionguard/rsa.c
+++ b/src/electionguard/rsa.c
@@ -37,8 +37,7 @@ void generate_keys(rsa_private_key* priv_key, rsa_public_key* pub_key)
     /* Select p */
     for(int i = 0; i < BUFFER_SIZE; i++)
     {
-        enum RandomSource_status source_status = RandomSource_get_byte(source, buffer[i]) % 0xFF;
-        assert(source_status == RANDOM_SOURCE_SUCCESS);
+        buffer[i] = RandomSource_get_byte(source) % 0xFF;
     }
 
     buffer[0] |= 0xC0;                                  // Set the top two bits to 1 to ensure int(tmp) is relatively large


### PR DESCRIPTION
### Issue

Fixes #85 

### Description
use Bcrypt on windows to generate random bytes.  Refactor the api to support returning an enum and filling an out parameter, as is consistent with other api's in the file.  This method signature change is consumed in the rsa.c file, and uses an `assert` to check the return code.  While we generally discourage the use of `assert` in application code, this was the most straightforward way to elicit the desired behavior without refactoring the entire method.

### Testing
1. run `makefile -f Makefile.mk run-api` in MSYS on Windows
2. Expected: all tests pass

### Checklist
🚨Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [x] 🤔 **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] ✅ **DO** check open PR's to avoid duplicates.
- [x] ✅ **DO** keep pull requests small so they can be easily reviewed.
- [x] ✅ **DO** build locally before pushing.
- [x] ✅ **DO** make sure tests pass.
- [x] ✅ **DO** make sure any new changes are documented.
- [x] ✅ **DO** make sure not to introduce any compiler warnings.
- [x] ❌**AVOID** breaking the continuous integration build.
- [x] ❌**AVOID** making significant changes to the overall architecture.

💔Thank you!